### PR TITLE
Add option to control micro:bit accelerometer with mouse

### DIFF
--- a/lib/skulpt/microbit/__init__.js
+++ b/lib/skulpt/microbit/__init__.js
@@ -1424,9 +1424,9 @@ var $builtinmodule = function (name) {
 			html += ' <span id="mb_pin_detail"></span>';
 			html += '</div>';
 			html += '<div id="mb_tabs_accelerometer">';
-			html += 'x: <span id="mb_acc_value_x">0</span><div class="mb_slider" id="mb_acc_slider_x"></div>';
-			html += 'y: <span id="mb_acc_value_y">0</span><div class="mb_slider" id="mb_acc_slider_y"></div>';
-			html += 'z: <span id="mb_acc_value_z">9</span><div class="mb_slider" id="mb_acc_slider_z"></div>';
+			html += 'x: <span id="mb_acc_value_x" class="mb_slider_acc">0</span><div class="mb_slider" id="mb_acc_slider_x"></div>';
+			html += 'y: <span id="mb_acc_value_y" class="mb_slider_acc">0</span><div class="mb_slider" id="mb_acc_slider_y"></div>';
+			html += 'z: <span id="mb_acc_value_z" class="mb_slider_acc">9</span><div class="mb_slider" id="mb_acc_slider_z"></div>';
 			html += '<span id="accel_check"><input type="checkbox" name="accel_check"><label for="accel_check">Move accelerometer with mouse</label></span>';
 			html += '<h3>Gestures</h3>';
 			html += '<span class="mb_help_link mb_gesture">up</span>';
@@ -1723,20 +1723,37 @@ var $builtinmodule = function (name) {
 				change: sliderChange
 			}).on("slide", sliderChange);
 
+			var accel_mouse_timer = null;
 			$('#accel_check :checkbox').change(function() {
 				if (this.checked) {
+					var mousemove_enabled = false;
 					const offset = $('#microbit').offset();
 					const height = $('#microbit').height();
 					const width = $('#microbit').width();
 					$('#microbit').mousemove(function (event) {
+						// debounce
+						if (!mousemove_enabled) {
+							return;
+						}
 						// Micro:bit accel values are +/- 2000, let's do half for sensitivity
 						const x = ((event.pageX - offset.left) / width) * 2000 - 1000;
 						const y = ((event.pageY - offset.top) / height) * 2000 - 1000;
 						mod.accelerometer.$d.data.x = x;
 						mod.accelerometer.$d.data.y = y;
+
+						$('#mb_acc_slider_x').slider('value', x);
+						$('#mb_acc_slider_y').slider('value', y);
+						$('#mb_acc_value_x').text(Math.floor(x));
+						$('#mb_acc_value_y').text(Math.floor(y));
+						mousemove_enabled = false;
 					});
+
+					accel_mouse_timer = window.setInterval(function () {
+						mousemove_enabled = true;
+					}, 30);
 				} else {
 					$('#microbit').off('mousemove');
+					window.clearInterval(accel_mouse_timer);
 				}
 			});
 			$('#mb_therm_slider').slider({

--- a/lib/skulpt/microbit/__init__.js
+++ b/lib/skulpt/microbit/__init__.js
@@ -124,11 +124,11 @@ var accelerometer = function(name) {
 	});
 
 	mod.get_y = new Sk.builtin.func(function() {
-		return new Sk.builtin.number(mod.data.y);
+		return new Sk.builtin.nmber(mod.data.y);
 	});
 
 	mod.get_z = new Sk.builtin.func(function() {
-		return new Sk.builtin.number(mod.data.z);
+		return new Sk.builtin.nmber(mod.data.z);
 	});
 
 	mod.get_values = new Sk.builtin.func(function() {
@@ -1427,6 +1427,7 @@ var $builtinmodule = function (name) {
 			html += 'x: <span id="mb_acc_value_x">0</span><div class="mb_slider" id="mb_acc_slider_x"></div>';
 			html += 'y: <span id="mb_acc_value_y">0</span><div class="mb_slider" id="mb_acc_slider_y"></div>';
 			html += 'z: <span id="mb_acc_value_z">9</span><div class="mb_slider" id="mb_acc_slider_z"></div>';
+			html += '<span id="accel_check"><input type="checkbox" name="accel_check"><label for="accel_check">Move accelerometer with mouse</label></span>';
 			html += '<h3>Gestures</h3>';
 			html += '<span class="mb_help_link mb_gesture">up</span>';
 			html += '<span class="mb_help_link mb_gesture">down</span>';
@@ -1721,6 +1722,23 @@ var $builtinmodule = function (name) {
 				step: 1,
 				change: sliderChange
 			}).on("slide", sliderChange);
+
+			$('#accel_check :checkbox').change(function() {
+				if (this.checked) {
+					const offset = $('#microbit').offset();
+					const height = $('#microbit').height();
+					const width = $('#microbit').width();
+					$('#microbit').mousemove(function (event) {
+						// Micro:bit accel values are +/- 2000, let's do half for sensitivity
+						const x = ((event.pageX - offset.left) / width) * 2000 - 1000;
+						const y = ((event.pageY - offset.top) / height) * 2000 - 1000;
+						mod.accelerometer.$d.data.x = x;
+						mod.accelerometer.$d.data.y = y;
+					});
+				} else {
+					$('#microbit').off('mousemove');
+				}
+			});
 			$('#mb_therm_slider').slider({
 				value: 23,
 				min: 0,

--- a/lib/skulpt/microbit/mb.css
+++ b/lib/skulpt/microbit/mb.css
@@ -98,7 +98,7 @@
 	height: 100px;
 	line-height: 100px;
 	text-align: center;
-	vertical-align: center;
+	vertical-align: middle;
 	background-image: url('compassbk.jpg');
 	position: relative;
 }
@@ -119,6 +119,10 @@
 	display: inline-block;
 	margin: 0px 10px 0px 10px;
 }
+.mb_slider_acc {
+    display: inline-block;
+    min-width: 2.5em;
+}
 #mb_gesture_list {
 	border-style: solid;
 	border-width: 1px;
@@ -127,16 +131,16 @@
 }
 .mb_current_gesture {
 	color: #F00;
-	margin; 1em;
+	margin: 1em;
 }
 .mb_active_gesture_down {
 	transform: rotate(180deg);
 }
 .mb_active_gesture_left, .mb_active_gesture_right {
-	-webkit-transform: rotateY(80deg);transform: rotateY(80deg);
+	transform: rotateY(80deg);
 }
 .mb_active_gesture_facedown {
-	-webkit-transform: rotateY(180deg);transform: rotateY(180deg);
+	transform: rotateY(180deg);
 }
 .mb_active_gesture_freefall {
 	transform: scale(0.2,0.2);


### PR DESCRIPTION
Firstly, thanks for making this, it's been a huge help in past workshops!

I have a workshop that gets people to build a snake game on micro:bit using the accelerometer. If they tilt the device forward, then the snake will move up the screen; if they tilt it to the left then the snake will move in a leftwards direction.

While this code can be simulated with this repository, it can be a bit inconvenient to have to adjust each accelerometer axis separately to make the snake move. This PR adds in the ability to change the accelerometer X and Y according to the mouse position.

![Screenshot from 2020-05-09 22-10-05](https://user-images.githubusercontent.com/4598381/81485108-9dbb0e00-9242-11ea-86aa-694a2b52ce5a.png)

I've added a checkbox to the accelerometer tab that allows this to be turned on and off since it would be surprising behaviour without explicitly requesting it. When the checkbox is ticked, the user can move the mouse within the `#microbit` element and the accelerometer values will change. In the snake example, it looks like the snake is trying to follow the mouse, which feels intuitive.

I tried to add animations which you can test out in the [mouse-accel-anim branch](https://github.com/notexactlyawe/createwithcode/tree/notexactlyawe/mouse-accel-anim) but I didn't like how they turned out. They made the screen more difficult to see, and it was hard to differentiate left from right and up from down.

If you want to test this code with the snake program, it's available in [ears-edi/microbit-snake](https://github.com/ears-edi/microbit-snake/blob/master/snake.py).

Let me know what you think!